### PR TITLE
Removed python3-incompatible keyword from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import codecs
 
 def readme(filename):
     in_file = codecs.open(filename, 'r')
-    return unicode(in_file.read())
+    return in_file.read()
 
 files = ["wemplate/*"]
 
@@ -24,7 +24,7 @@ setup(name = "wempy",
                                     ]
                     },
     scripts = ["wempy"],
-    long_description = readme('README'),
+    long_description = readme('README.rst'),
     classifiers = [
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',
@@ -36,6 +36,14 @@ setup(name = "wempy",
         'Programming Language :: Python :: 2.5',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.0',
+        'Programming Language :: Python :: 3.1',
+        'Programming Language :: Python :: 3.2',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: Jython',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',


### PR DESCRIPTION
The `setup.py` script was using a python3-incompatible keyword. The `readme()` function was referencing an invalid file.